### PR TITLE
Update Scala versions and add Scala 2.12 to CI

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   check-code-style:
     name: Checks
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     if: github.repository == 'apache/incubator-pekko-persistence-r2dbc'
     steps:
       - name: Checkout
@@ -18,24 +18,63 @@ jobs:
         with:
           # we don't know what commit the last tag was it's safer to get entire repo so previousStableVersion resolves
           fetch-depth: 0
+
       - name: Checkout GitHub merge
         if: github.event.pull_request
         run: |-
           git fetch origin pull/${{ github.event.pull_request.number }}/merge:scratch
           git checkout scratch
+
       - name: Set up JDK 11
-        uses: olafurpg/setup-scala@v10
+        uses: actions/setup-java@v3
         with:
-          java-version: adopt@1.11.0-9
+          distribution: temurin
+          java-version: 11
+
       - name: Cache Coursier cache
         uses: coursier/cache-action@v6.4.0
+
+      - name: Enable jvm-opts
+        run: cp .jvmopts-ci .jvmopts
+
       - name: Code style check and binary-compatibility check
         run: |-
-          sbt -jvm-opts .jvmopts-ci scalafmtCheckAll scalafmtSbtCheck headerCheck
+          sbt scalafmtCheckAll scalafmtSbtCheck headerCheck
+  compile:
+    name: Test and compile
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        SCALA_VERSION: [ 2.12, 2.13 ]
+        JAVA_VERSION: [ 8, 11 ]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Setup Java ${{ matrix.JAVA_VERSION }}
+        uses: actions/setup-java@v3
+        with:
+          distribution: temurin
+          java-version: ${{ matrix.JAVA_VERSION }}
+
+      - name: Cache Coursier cache
+        uses: coursier/cache-action@v6
+
+      - name: Enable jvm-opts
+        run: cp .jvmopts-ci .jvmopts
+
+      - name: Compile and test for JDK ${{ matrix.JAVA_VERSION }}, Scala ${{ matrix.SCALA_VERSION }}
+        run: sbt ++${{ matrix.SCALA_VERSION }} test:compile
 
   test-postgres:
     name: Run test with Postgres
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        SCALA_VERSION: [ 2.12, 2.13 ]
+        JAVA_VERSION: [ 8, 11 ]
     if: github.repository == 'apache/incubator-pekko-persistence-r2dbc'
     steps:
       - name: Checkout
@@ -49,13 +88,17 @@ jobs:
           git fetch origin pull/${{ github.event.pull_request.number }}/merge:scratch
           git checkout scratch
 
-      - name: Set up JDK 11
-        uses: olafurpg/setup-scala@v10
+      - name: Setup Java ${{ matrix.JAVA_VERSION }}
+        uses: actions/setup-java@v3
         with:
-          java-version: adopt@1.11.0-9
+          distribution: temurin
+          java-version: ${{ matrix.JAVA_VERSION }}
 
       - name: Cache Coursier cache
         uses: coursier/cache-action@v6.4.0
+
+      - name: Enable jvm-opts
+        run: cp .jvmopts-ci .jvmopts
 
       - name: Start DB
         run: |-
@@ -65,11 +108,15 @@ jobs:
           docker exec -i docker_postgres-db_1 psql -U postgres -t < ddl-scripts/create_tables_postgres.sql
 
       - name: test
-        run: sbt test
+        run: sbt ++${{ matrix.SCALA_VERSION }} test
 
   test-yugabyte:
     name: Run tests with Yugabyte
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        SCALA_VERSION: [ 2.12, 2.13 ]
+        JAVA_VERSION: [ 8, 11 ]
     if: github.repository == 'apache/incubator-pekko-persistence-r2dbc'
     steps:
       - name: Checkout
@@ -83,13 +130,17 @@ jobs:
           git fetch origin pull/${{ github.event.pull_request.number }}/merge:scratch
           git checkout scratch
 
-      - name: Set up JDK 11
-        uses: olafurpg/setup-scala@v10
+      - name: Setup Java ${{ matrix.JAVA_VERSION }}
+        uses: actions/setup-java@v3
         with:
-          java-version: adopt@1.11.0-9
+          distribution: temurin
+          java-version: ${{ matrix.JAVA_VERSION }}
 
       - name: Cache Coursier cache
         uses: coursier/cache-action@v6.4.0
+
+      - name: Enable jvm-opts
+        run: cp .jvmopts-ci .jvmopts
 
       - name: Start DB
         run: |-
@@ -99,28 +150,36 @@ jobs:
           docker exec -i yb-tserver-n1 /home/yugabyte/bin/ysqlsh -h yb-tserver-n1 -t < ddl-scripts/create_tables_yugabyte.sql
 
       - name: test
-        run: sbt -Dakka.persistence.r2dbc.dialect=yugabyte -Dakka.projection.r2dbc.dialect=yugabyte test
+        run: sbt -Dakka.persistence.r2dbc.dialect=yugabyte -Dakka.projection.r2dbc.dialect=yugabyte ++${{ matrix.SCALA_VERSION }} test
 
   test-docs:
     name: Docs
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     if: github.repository == 'apache/incubator-pekko-persistence-r2dbc'
     steps:
       - name: Checkout
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
+
       - name: Checkout GitHub merge
         if: github.event.pull_request
         run: |-
           git fetch origin pull/${{ github.event.pull_request.number }}/merge:scratch
           git checkout scratch
+
       - name: Set up JDK 11
-        uses: olafurpg/setup-scala@v10
+        uses: actions/setup-java@v3
         with:
-          java-version: adopt@1.11.0-9
+          distribution: temurin
+          java-version: 11
+
       - name: Cache Coursier cache
         uses: coursier/cache-action@v6.4.0
-      - name: Test Maven Java
+
+      - name: Enable jvm-opts
+        run: cp .jvmopts-ci .jvmopts
+
+      - name: Compile docs
         run: |-
-          sbt -jvm-opts .jvmopts-ci docs/paradox
+          sbt docs/paradox

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   sbt:
     name: sbt publish
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     if: github.repository == 'apache/incubator-pekko-persistence-r2dbc'
     steps:
       - name: Checkout
@@ -17,13 +17,19 @@ jobs:
         with:
           # we don't know what commit the last tag was it's safer to get entire repo so previousStableVersion resolves
           fetch-depth: 0
+
       - name: Set up JDK 8
-        uses: olafurpg/setup-scala@v10
+        uses: actions/setup-java@v3
         with:
-          java-version: adopt@1.8.0-275
+          distribution: temurin
+          java-version: 8
+
+      - name: Enable jvm-opts
+        run: cp .jvmopts-ci .jvmopts
+
       - name: Publish
         run: |-
-          sbt -jvm-opts .jvmopts-ci ci-release
+          sbt ci-release
         env:
           PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
           PGP_SECRET: ${{ secrets.PGP_SECRET }}
@@ -32,7 +38,7 @@ jobs:
 
   documentation:
     name: Documentation
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     if: github.repository == 'apache/incubator-pekko-persistence-r2dbc'
     steps:
       - name: Checkout
@@ -40,10 +46,16 @@ jobs:
         with:
           # we don't know what commit the last tag was it's safer to get entire repo so previousStableVersion resolves
           fetch-depth: 0
+
       - name: Set up JDK 8
-        uses: olafurpg/setup-scala@v10
+        uses: actions/setup-java@v3
         with:
-          java-version: adopt@1.8.0-275
+          distribution: temurin
+          java-version: 8
+
+      - name: Enable jvm-opts
+        run: cp .jvmopts-ci .jvmopts
+
       - name: Publish
         run: |-
           eval "$(ssh-agent -s)"

--- a/build.sbt
+++ b/build.sbt
@@ -29,7 +29,7 @@ inThisBuild(
 
 def common: Seq[Setting[_]] =
   Seq(
-    crossScalaVersions := Seq(Dependencies.Scala213),
+    crossScalaVersions := Seq(Dependencies.Scala212, Dependencies.Scala213),
     scalaVersion := Dependencies.Scala213,
     crossVersion := CrossVersion.binary,
     scalafmtOnCompile := true,

--- a/core/src/main/scala/akka/persistence/r2dbc/ConnectionFactoryProvider.scala
+++ b/core/src/main/scala/akka/persistence/r2dbc/ConnectionFactoryProvider.scala
@@ -9,7 +9,6 @@ import java.util.concurrent.ConcurrentHashMap
 
 import scala.concurrent.Future
 import scala.concurrent.duration.Duration
-import scala.jdk.CollectionConverters.ConcurrentMapHasAsScala
 
 import akka.Done
 import akka.actor.CoordinatedShutdown
@@ -17,6 +16,7 @@ import akka.actor.typed.ActorSystem
 import akka.actor.typed.Extension
 import akka.actor.typed.ExtensionId
 import akka.persistence.r2dbc.internal.R2dbcExecutor
+import akka.util.ccompat.JavaConverters._
 import io.r2dbc.pool.ConnectionPool
 import io.r2dbc.pool.ConnectionPoolConfiguration
 import io.r2dbc.postgresql.PostgresqlConnectionFactoryProvider

--- a/core/src/main/scala/akka/persistence/r2dbc/internal/BySliceQuery.scala
+++ b/core/src/main/scala/akka/persistence/r2dbc/internal/BySliceQuery.scala
@@ -219,12 +219,12 @@ import org.slf4j.Logger
           log.debug(
             "{} next query [{}] from slices [{} - {}], between time [{} - {}]. Found [{}] rows in previous query.",
             logPrefix,
-            state.queryCount,
-            minSlice,
-            maxSlice,
+            state.queryCount: java.lang.Long,
+            minSlice: java.lang.Integer,
+            maxSlice: java.lang.Integer,
             state.latest.timestamp,
             toTimestamp,
-            state.rowCount)
+            state.rowCount: java.lang.Integer)
 
         newState -> Some(
           dao
@@ -242,10 +242,10 @@ import org.slf4j.Logger
           log.debug(
             "{} query [{}] from slices [{} - {}] completed. Found [{}] rows in previous query.",
             logPrefix,
-            state.queryCount,
-            minSlice,
-            maxSlice,
-            state.rowCount)
+            state.queryCount: java.lang.Long,
+            minSlice: java.lang.Integer,
+            maxSlice: java.lang.Integer,
+            state.rowCount: java.lang.Integer)
 
         state -> None
       }
@@ -258,8 +258,8 @@ import org.slf4j.Logger
             log.debug(
               "{} query slices [{} - {}], from time [{}] until now [{}].",
               logPrefix,
-              minSlice,
-              maxSlice,
+              minSlice: java.lang.Integer,
+              maxSlice: java.lang.Integer,
               initialOffset.timestamp,
               currentDbTime)
 
@@ -286,8 +286,8 @@ import org.slf4j.Logger
       log.debug(
         "Starting {} query from slices [{} - {}], from time [{}].",
         logPrefix,
-        minSlice,
-        maxSlice,
+        minSlice: java.lang.Integer,
+        maxSlice: java.lang.Integer,
         initialOffset.timestamp)
 
     def nextOffset(state: QueryState, envelope: Envelope): QueryState = {
@@ -321,10 +321,10 @@ import org.slf4j.Logger
             log.debug(
               "{} query [{}] from slices [{} - {}] delay next [{}] ms.",
               logPrefix,
-              state.queryCount,
-              minSlice,
-              maxSlice,
-              d.toMillis)
+              state.queryCount: java.lang.Long,
+              minSlice: java.lang.Integer,
+              maxSlice: java.lang.Integer,
+              d.toMillis: java.lang.Long)
           }
 
         delay
@@ -376,12 +376,12 @@ import org.slf4j.Logger
         log.debug(
           "{} next query [{}]{} from slices [{} - {}], between time [{} - {}]. {}",
           logPrefix,
-          newState.queryCount,
+          newState.queryCount: java.lang.Long,
           if (newState.backtracking) " in backtracking mode" else "",
-          minSlice,
-          maxSlice,
+          minSlice: java.lang.Integer,
+          maxSlice: java.lang.Integer,
           fromTimestamp,
-          toTimestamp.getOrElse("None"),
+          toTimestamp.getOrElse(None),
           if (newIdleCount >= 3) s"Idle in [$newIdleCount] queries."
           else if (state.backtracking) s"Found [${state.rowCount}] rows in previous backtracking query."
           else s"Found [${state.rowCount}] rows in previous query.")
@@ -441,10 +441,10 @@ import org.slf4j.Logger
             log.debug(
               "{} retrieved [{}] event count buckets, with a total of [{}], from slices [{} - {}], from time [{}]",
               logPrefix,
-              counts.size,
-              sum,
-              minSlice,
-              maxSlice,
+              counts.size: java.lang.Integer,
+              sum: java.lang.Long,
+              minSlice: java.lang.Integer,
+              maxSlice: java.lang.Integer,
               fromTimestamp)
           }
           newState
@@ -472,7 +472,7 @@ import org.slf4j.Logger
             log.trace(
               "filtering [{}] [{}] as db timestamp is the same as last offset and is in seen [{}]",
               row.persistenceId,
-              row.seqNr,
+              row.seqNr: java.lang.Long,
               currentSequenceNrs)
             Nil
           } else {

--- a/core/src/main/scala/akka/persistence/r2dbc/journal/JournalDao.scala
+++ b/core/src/main/scala/akka/persistence/r2dbc/journal/JournalDao.scala
@@ -11,6 +11,7 @@ import scala.concurrent.Future
 
 import akka.actor.typed.ActorSystem
 import akka.annotation.InternalApi
+import akka.dispatch.ExecutionContexts
 import akka.persistence.Persistence
 import akka.persistence.r2dbc.R2dbcSettings
 import akka.persistence.r2dbc.internal.Sql.Interpolation
@@ -219,7 +220,7 @@ private[r2dbc] class JournalDao(journalSettings: R2dbcSettings, connectionFactor
         result.foreach { _ =>
           log.debug("Wrote [{}] events for persistenceId [{}]", 1, events.head.persistenceId)
         }
-      result.map(_.head)(ExecutionContext.parasitic)
+      result.map(_.head)(ExecutionContexts.parasitic)
     }
   }
 
@@ -235,7 +236,7 @@ private[r2dbc] class JournalDao(journalSettings: R2dbcSettings, connectionFactor
           val seqNr = row.get(0, classOf[java.lang.Long])
           if (seqNr eq null) 0L else seqNr.longValue
         })
-      .map(r => if (r.isEmpty) 0L else r.head)(ExecutionContext.parasitic)
+      .map(r => if (r.isEmpty) 0L else r.head)(ExecutionContexts.parasitic)
 
     if (log.isDebugEnabled)
       result.foreach(seqNr => log.debug("Highest sequence nr for persistenceId [{}]: [{}]", persistenceId, seqNr))
@@ -281,7 +282,7 @@ private[r2dbc] class JournalDao(journalSettings: R2dbcSettings, connectionFactor
         result.foreach(updatedRows =>
           log.debug("Deleted [{}] events for persistenceId [{}]", updatedRows.head, persistenceId))
 
-      result.map(_ => ())(ExecutionContext.parasitic)
+      result.map(_ => ())(ExecutionContexts.parasitic)
     }
   }
 

--- a/core/src/main/scala/akka/persistence/r2dbc/query/scaladsl/QueryDao.scala
+++ b/core/src/main/scala/akka/persistence/r2dbc/query/scaladsl/QueryDao.scala
@@ -197,7 +197,9 @@ private[r2dbc] class QueryDao(settings: R2dbcSettings, connectionFactory: Connec
             metadata = readMetadata(row)))
 
     if (log.isDebugEnabled)
-      result.foreach(rows => log.debug("Read [{}] events from slices [{} - {}]", rows.size, minSlice, maxSlice))
+      result.foreach(rows =>
+        log.debug("Read [{}] events from slices [{} - {}]", rows.size: java.lang.Integer, minSlice: java.lang.Integer,
+          maxSlice: java.lang.Integer))
 
     Source.futureSource(result.map(Source(_))).mapMaterializedValue(_ => NotUsed)
   }
@@ -235,7 +237,10 @@ private[r2dbc] class QueryDao(settings: R2dbcSettings, connectionFactory: Connec
       })
 
     if (log.isDebugEnabled)
-      result.foreach(rows => log.debug("Read [{}] bucket counts from slices [{} - {}]", rows.size, minSlice, maxSlice))
+      result.foreach(rows =>
+        log.debug("Read [{}] bucket counts from slices [{} - {}]", rows.size: java.lang.Integer,
+          minSlice: java.lang.Integer,
+          maxSlice: java.lang.Integer))
 
     result
   }

--- a/core/src/main/scala/akka/persistence/r2dbc/query/scaladsl/R2dbcReadJournal.scala
+++ b/core/src/main/scala/akka/persistence/r2dbc/query/scaladsl/R2dbcReadJournal.scala
@@ -250,11 +250,11 @@ final class R2dbcReadJournal(system: ExtendedActorSystem, config: Config, cfgPat
         if (state.queryCount != 0 && log.isDebugEnabled())
           log.debug(
             "currentEventsByPersistenceId query [{}] for persistenceId [{}], from [{}] to [{}]. Found [{}] rows in previous query.",
-            state.queryCount,
+            state.queryCount: java.lang.Integer,
             persistenceId,
-            state.latestSeqNr + 1,
-            highestSeqNr,
-            state.rowCount)
+            state.latestSeqNr + 1: java.lang.Long,
+            highestSeqNr: java.lang.Long,
+            state.rowCount: java.lang.Integer)
 
         newState -> Some(
           queryDao
@@ -262,9 +262,9 @@ final class R2dbcReadJournal(system: ExtendedActorSystem, config: Config, cfgPat
       } else {
         log.debug(
           "currentEventsByPersistenceId query [{}] for persistenceId [{}] completed. Found [{}] rows in previous query.",
-          state.queryCount,
+          state.queryCount: java.lang.Integer,
           persistenceId,
-          state.rowCount)
+          state.rowCount: java.lang.Integer)
 
         state -> None
       }
@@ -274,8 +274,8 @@ final class R2dbcReadJournal(system: ExtendedActorSystem, config: Config, cfgPat
       log.debug(
         "currentEventsByPersistenceId query for persistenceId [{}], from [{}] to [{}].",
         persistenceId,
-        fromSequenceNr,
-        toSequenceNr)
+        fromSequenceNr: java.lang.Long,
+        toSequenceNr: java.lang.Long)
 
     ContinuousQuery[ByPersistenceIdState, SerializedJournalRow](
       initialState = ByPersistenceIdState(0, 0, latestSeqNr = fromSequenceNr - 1),
@@ -320,9 +320,9 @@ final class R2dbcReadJournal(system: ExtendedActorSystem, config: Config, cfgPat
       delay.foreach { d =>
         log.debug(
           "eventsByPersistenceId query [{}] for persistenceId [{}] delay next [{}] ms.",
-          state.queryCount,
+          state.queryCount: java.lang.Integer,
           persistenceId,
-          d.toMillis)
+          d.toMillis: java.lang.Long)
       }
 
       delay
@@ -333,18 +333,18 @@ final class R2dbcReadJournal(system: ExtendedActorSystem, config: Config, cfgPat
       if (state.latestSeqNr >= toSequenceNr) {
         log.debug(
           "eventsByPersistenceId query [{}] for persistenceId [{}] completed. Found [{}] rows in previous query.",
-          state.queryCount,
+          state.queryCount: java.lang.Integer,
           persistenceId,
-          state.rowCount)
+          state.rowCount: java.lang.Integer)
         state -> None
       } else {
         val newState = state.copy(rowCount = 0, queryCount = state.queryCount + 1)
 
         log.debug(
           "eventsByPersistenceId query [{}] for persistenceId [{}], from [{}]. Found [{}] rows in previous query.",
-          newState.queryCount,
+          newState.queryCount: java.lang.Integer,
           persistenceId,
-          state.rowCount)
+          state.rowCount: java.lang.Integer)
 
         newState ->
         Some(
@@ -405,9 +405,9 @@ final class R2dbcReadJournal(system: ExtendedActorSystem, config: Config, cfgPat
         if (state.queryCount != 0 && log.isDebugEnabled())
           log.debug(
             "persistenceIds query [{}] after [{}]. Found [{}] rows in previous query.",
-            state.queryCount,
+            state.queryCount: java.lang.Integer,
             state.latestPid,
-            state.rowCount)
+            state.rowCount: java.lang.Integer)
 
         newState -> Some(
           queryDao

--- a/core/src/main/scala/akka/persistence/r2dbc/state/javadsl/R2dbcDurableStateStore.scala
+++ b/core/src/main/scala/akka/persistence/r2dbc/state/javadsl/R2dbcDurableStateStore.scala
@@ -9,7 +9,7 @@ import java.util.Optional
 import java.util.concurrent.CompletionStage
 
 import scala.concurrent.ExecutionContext
-import scala.jdk.FutureConverters.FutureOps
+import scala.compat.java8.FutureConverters.FutureOps
 
 import akka.Done
 import akka.NotUsed
@@ -36,13 +36,13 @@ class R2dbcDurableStateStore[A](scalaStore: ScalaR2dbcDurableStateStore[A])(impl
     scalaStore
       .getObject(persistenceId)
       .map(x => GetObjectResult(Optional.ofNullable(x.value.getOrElse(null.asInstanceOf[A])), x.revision))
-      .asJava
+      .toJava
 
   override def upsertObject(persistenceId: String, revision: Long, value: A, tag: String): CompletionStage[Done] =
-    scalaStore.upsertObject(persistenceId, revision, value, tag).asJava
+    scalaStore.upsertObject(persistenceId, revision, value, tag).toJava
 
   override def deleteObject(persistenceId: String): CompletionStage[Done] =
-    scalaStore.deleteObject(persistenceId).asJava
+    scalaStore.deleteObject(persistenceId).toJava
 
   override def currentChangesBySlices(
       entityType: String,

--- a/core/src/main/scala/akka/persistence/r2dbc/state/scaladsl/DurableStateDao.scala
+++ b/core/src/main/scala/akka/persistence/r2dbc/state/scaladsl/DurableStateDao.scala
@@ -15,6 +15,7 @@ import akka.Done
 import akka.NotUsed
 import akka.actor.typed.ActorSystem
 import akka.annotation.InternalApi
+import akka.dispatch.ExecutionContexts
 import akka.persistence.Persistence
 import akka.persistence.r2dbc.Dialect
 import akka.persistence.r2dbc.R2dbcSettings
@@ -267,7 +268,7 @@ private[r2dbc] class DurableStateDao(settings: R2dbcSettings, connectionFactory:
     if (log.isDebugEnabled())
       result.foreach(_ => log.debug("Deleted durable state for persistenceId [{}]", persistenceId))
 
-    result.map(_ => Done)(ExecutionContext.parasitic)
+    result.map(_ => Done)(ExecutionContexts.parasitic)
   }
 
   override def currentDbTimestamp(): Future[Instant] = {
@@ -335,7 +336,10 @@ private[r2dbc] class DurableStateDao(settings: R2dbcSettings, connectionFactory:
           ))
 
     if (log.isDebugEnabled)
-      result.foreach(rows => log.debug("Read [{}] durable states from slices [{} - {}]", rows.size, minSlice, maxSlice))
+      result.foreach(rows =>
+        log.debug("Read [{}] durable states from slices [{} - {}]", rows.size: java.lang.Integer,
+          minSlice: java.lang.Integer,
+          maxSlice: java.lang.Integer))
 
     Source.futureSource(result.map(Source(_))).mapMaterializedValue(_ => NotUsed)
   }
@@ -401,7 +405,10 @@ private[r2dbc] class DurableStateDao(settings: R2dbcSettings, connectionFactory:
       })
 
     if (log.isDebugEnabled)
-      result.foreach(rows => log.debug("Read [{}] bucket counts from slices [{} - {}]", rows.size, minSlice, maxSlice))
+      result.foreach(rows =>
+        log.debug("Read [{}] bucket counts from slices [{} - {}]", rows.size: java.lang.Integer,
+          minSlice: java.lang.Integer,
+          maxSlice: java.lang.Integer))
 
     result
 

--- a/core/src/main/scala/akka/persistence/r2dbc/state/scaladsl/R2dbcDurableStateStore.scala
+++ b/core/src/main/scala/akka/persistence/r2dbc/state/scaladsl/R2dbcDurableStateStore.scala
@@ -139,9 +139,9 @@ class R2dbcDurableStateStore[A](system: ExtendedActorSystem, config: Config, cfg
         if (state.queryCount != 0 && log.isDebugEnabled())
           log.debug(
             "persistenceIds query [{}] after [{}]. Found [{}] rows in previous query.",
-            state.queryCount,
+            state.queryCount: java.lang.Integer,
             state.latestPid,
-            state.rowCount)
+            state.rowCount: java.lang.Integer)
 
         newState -> Some(
           stateDao

--- a/core/src/test/scala/akka/persistence/r2dbc/TestActors.scala
+++ b/core/src/test/scala/akka/persistence/r2dbc/TestActors.scala
@@ -66,17 +66,17 @@ object TestActors {
           command match {
             case command: Persist =>
               context.log.debug(
-                "Persist [{}], pid [{}], seqNr [{}]",
-                command.payload,
-                pid.id,
-                EventSourcedBehavior.lastSequenceNumber(context) + 1)
+                "Persist [{}], pid [{}], seqNr [{}]": String,
+                command.payload.toString,
+                pid.id: Object,
+                EventSourcedBehavior.lastSequenceNumber(context) + 1: java.lang.Long)
               Effect.persist(command.payload)
             case command: PersistWithAck =>
               context.log.debug(
                 "Persist [{}], pid [{}], seqNr [{}]",
-                command.payload,
+                command.payload.toString,
                 pid.id,
-                EventSourcedBehavior.lastSequenceNumber(context) + 1)
+                EventSourcedBehavior.lastSequenceNumber(context) + 1: java.lang.Long)
               Effect.persist(command.payload).thenRun(_ => command.replyTo ! Done)
             case command: PersistAll =>
               if (context.log.isDebugEnabled)
@@ -84,7 +84,7 @@ object TestActors {
                   "PersistAll [{}], pid [{}], seqNr [{}]",
                   command.payloads.mkString(","),
                   pid.id,
-                  EventSourcedBehavior.lastSequenceNumber(context) + 1)
+                  EventSourcedBehavior.lastSequenceNumber(context) + 1: java.lang.Long)
               Effect.persist(command.payloads)
             case Ping(replyTo) =>
               replyTo ! Done
@@ -123,16 +123,16 @@ object TestActors {
               case command: Persist =>
                 context.log.debug(
                   "Persist [{}], pid [{}], seqNr [{}]",
-                  command.payload,
-                  pid.id,
-                  DurableStateBehavior.lastSequenceNumber(context) + 1)
+                  command.payload.toString,
+                  pid.id: Object,
+                  (DurableStateBehavior.lastSequenceNumber(context) + 1: java.lang.Long): Object)
                 Effect.persist(command.payload)
               case command: PersistWithAck =>
                 context.log.debug(
                   "Persist [{}], pid [{}], seqNr [{}]",
-                  command.payload,
-                  pid.id,
-                  DurableStateBehavior.lastSequenceNumber(context) + 1)
+                  command.payload.toString,
+                  pid.id: Object,
+                  (DurableStateBehavior.lastSequenceNumber(context) + 1: java.lang.Long): Object)
                 Effect.persist(command.payload).thenRun(_ => command.replyTo ! Done)
               case Ping(replyTo) =>
                 replyTo ! Done

--- a/core/src/test/scala/akka/persistence/r2dbc/query/EventsBySliceBacktrackingSpec.scala
+++ b/core/src/test/scala/akka/persistence/r2dbc/query/EventsBySliceBacktrackingSpec.scala
@@ -44,7 +44,7 @@ class EventsBySliceBacktrackingSpec
 
   // to be able to store events with specific timestamps
   private def writeEvent(slice: Int, persistenceId: String, seqNr: Long, timestamp: Instant, event: String): Unit = {
-    log.debug("Write test event [{}] [{}] [{}] at time [{}]", persistenceId, seqNr, event, timestamp)
+    log.debug("Write test event [{}] [{}] [{}] at time [{}]", persistenceId, seqNr: java.lang.Long, event, timestamp)
     val insertEventSql = sql"""
       INSERT INTO ${settings.journalTableWithSchema}
       (slice, entity_type, persistence_id, seq_nr, db_timestamp, writer, adapter_manifest, event_ser_id, event_ser_manifest, event_payload)

--- a/migration/src/main/scala/akka/persistence/r2dbc/migration/MigrationToolDao.scala
+++ b/migration/src/main/scala/akka/persistence/r2dbc/migration/MigrationToolDao.scala
@@ -11,6 +11,7 @@ import scala.concurrent.duration.FiniteDuration
 import akka.Done
 import akka.actor.typed.ActorSystem
 import akka.annotation.InternalApi
+import akka.dispatch.ExecutionContexts
 import akka.persistence.r2dbc.internal.Sql.Interpolation
 import akka.persistence.r2dbc.internal.R2dbcExecutor
 import akka.persistence.r2dbc.journal.JournalDao.log
@@ -59,7 +60,7 @@ import io.r2dbc.spi.ConnectionFactory
           .bind(0, persistenceId)
           .bind(1, seqNr)
       }
-      .map(_ => Done)(ExecutionContext.parasitic)
+      .map(_ => Done)(ExecutionContexts.parasitic)
   }
 
   def updateSnapshotProgress(persistenceId: String, seqNr: Long): Future[Done] = {
@@ -76,7 +77,7 @@ import io.r2dbc.spi.ConnectionFactory
           .bind(0, persistenceId)
           .bind(1, seqNr)
       }
-      .map(_ => Done)(ExecutionContext.parasitic)
+      .map(_ => Done)(ExecutionContexts.parasitic)
   }
 
   def currentProgress(persistenceId: String): Future[Option[CurrentProgress]] = {

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -5,8 +5,8 @@
 import sbt._
 
 object Dependencies {
-  val Scala212 = "2.12.16"
-  val Scala213 = "2.13.8"
+  val Scala212 = "2.12.17"
+  val Scala213 = "2.13.10"
   val AkkaVersion = System.getProperty("override.akka.version", "2.6.19")
   val AkkaVersionInDocs = AkkaVersion.take(3)
   val AkkaProjectionVersion = "1.2.4"

--- a/projection/src/main/scala/akka/projection/r2dbc/internal/BySliceSourceProviderAdapter.scala
+++ b/projection/src/main/scala/akka/projection/r2dbc/internal/BySliceSourceProviderAdapter.scala
@@ -15,6 +15,7 @@ import akka.NotUsed
 import akka.annotation.InternalApi
 import akka.projection.javadsl
 import akka.projection.scaladsl
+import akka.dispatch.ExecutionContexts
 import akka.stream.scaladsl.Source
 import scala.compat.java8.FutureConverters._
 
@@ -60,7 +61,7 @@ import akka.projection.BySlicesSourceProvider
   override def timestampOf(persistenceId: String, sequenceNr: Long): Future[Option[Instant]] =
     delegate match {
       case timestampQuery: akka.persistence.query.typed.javadsl.EventTimestampQuery =>
-        timestampQuery.timestampOf(persistenceId, sequenceNr).toScala.map(_.asScala)(ExecutionContext.parasitic)
+        timestampQuery.timestampOf(persistenceId, sequenceNr).toScala.map(_.asScala)(ExecutionContexts.parasitic)
       case _ =>
         Future.failed(
           new IllegalArgumentException(

--- a/projection/src/main/scala/akka/projection/r2dbc/internal/R2dbcProjectionImpl.scala
+++ b/projection/src/main/scala/akka/projection/r2dbc/internal/R2dbcProjectionImpl.scala
@@ -101,9 +101,12 @@ private[projection] object R2dbcProjectionImpl {
         }).map { loadedEnv =>
           val count = loadEnvelopeCounter.incrementAndGet()
           if (count % 1000 == 0)
-            log.info("Loaded event lazily, persistenceId [{}], seqNr [{}]. Load count [{}]", pid, seqNr, count)
+            log.info("Loaded event lazily, persistenceId [{}], seqNr [{}]. Load count [{}]", pid, seqNr: java.lang.Long,
+              count: java.lang.Long)
           else
-            log.debug("Loaded event lazily, persistenceId [{}], seqNr [{}]. Load count [{}]", pid, seqNr, count)
+            log.debug("Loaded event lazily, persistenceId [{}], seqNr [{}]. Load count [{}]", pid,
+              seqNr: java.lang.Long,
+              count: java.lang.Long)
           loadedEnv.asInstanceOf[Envelope]
         }
 
@@ -123,14 +126,14 @@ private[projection] object R2dbcProjectionImpl {
               log.info(
                 "Loaded durable state lazily, persistenceId [{}], revision [{}]. Load count [{}]",
                 pid,
-                loadedRevision,
-                count)
+                loadedRevision: java.lang.Long,
+                count: java.lang.Long)
             else
               log.debug(
                 "Loaded durable state lazily, persistenceId [{}], revision [{}]. Load count [{}]",
                 pid,
-                loadedRevision,
-                count)
+                loadedRevision: java.lang.Long,
+                count: java.lang.Long)
             new UpdatedDurableState(pid, loadedRevision, loadedValue, upd.offset, upd.timestamp)
               .asInstanceOf[Envelope]
           case GetObjectResult(None, _) =>
@@ -524,7 +527,7 @@ private[projection] class R2dbcProjectionImpl[Offset, Envelope](
 
     override protected def saveOffsetsAndReport(
         projectionId: ProjectionId,
-        batch: Seq[ProjectionContextImpl[Offset, Envelope]]): Future[Done] = {
+        batch: immutable.Seq[ProjectionContextImpl[Offset, Envelope]]): Future[Done] = {
       import R2dbcProjectionImpl.FutureDone
 
       val acceptedContexts =

--- a/projection/src/main/scala/akka/projection/r2dbc/javadsl/R2dbcSession.scala
+++ b/projection/src/main/scala/akka/projection/r2dbc/javadsl/R2dbcSession.scala
@@ -10,11 +10,12 @@ import java.util.concurrent.CompletionStage
 import scala.compat.java8.FutureConverters._
 import scala.compat.java8.OptionConverters._
 import scala.concurrent.ExecutionContext
-import scala.jdk.CollectionConverters._
 
 import akka.actor.typed.ActorSystem
 import akka.annotation.ApiMayChange
+import akka.dispatch.ExecutionContexts
 import akka.persistence.r2dbc.internal.R2dbcExecutor
+import akka.util.ccompat.JavaConverters._
 import io.r2dbc.spi.Connection
 import io.r2dbc.spi.Row
 import io.r2dbc.spi.Statement
@@ -26,13 +27,13 @@ final class R2dbcSession(connection: Connection)(implicit ec: ExecutionContext, 
     connection.createStatement(sql)
 
   def updateOne(statement: Statement): CompletionStage[Integer] =
-    R2dbcExecutor.updateOneInTx(statement).map(Integer.valueOf)(ExecutionContext.parasitic).toJava
+    R2dbcExecutor.updateOneInTx(statement).map(Integer.valueOf)(ExecutionContexts.parasitic).toJava
 
   def update(statements: java.util.List[Statement]): CompletionStage[java.util.List[Integer]] =
     R2dbcExecutor.updateInTx(statements.asScala.toVector).map(results => results.map(Integer.valueOf).asJava).toJava
 
   def selectOne[A](statement: Statement)(mapRow: Row => A): CompletionStage[Optional[A]] =
-    R2dbcExecutor.selectOneInTx(statement, mapRow).map(_.asJava)(ExecutionContext.parasitic).toJava
+    R2dbcExecutor.selectOneInTx(statement, mapRow).map(_.asJava)(ExecutionContexts.parasitic).toJava
 
   def select[A](statement: Statement)(mapRow: Row => A): CompletionStage[java.util.List[A]] =
     R2dbcExecutor.selectInTx(statement, mapRow).map(_.asJava).toJava

--- a/projection/src/test/scala/akka/projection/r2dbc/DurableStateEndToEndSpec.scala
+++ b/projection/src/test/scala/akka/projection/r2dbc/DurableStateEndToEndSpec.scala
@@ -68,16 +68,16 @@ object DurableStateEndToEndSpec {
               case command: Persist =>
                 context.log.debug(
                   "Persist [{}], pid [{}], seqNr [{}]",
-                  command.payload,
+                  command.payload.toString,
                   pid.id,
-                  DurableStateBehavior.lastSequenceNumber(context) + 1)
+                  DurableStateBehavior.lastSequenceNumber(context) + 1: java.lang.Long)
                 Effect.persist(command.payload)
               case command: PersistWithAck =>
                 context.log.debug(
                   "Persist [{}], pid [{}], seqNr [{}]",
-                  command.payload,
+                  command.payload.toString,
                   pid.id,
-                  DurableStateBehavior.lastSequenceNumber(context) + 1)
+                  DurableStateBehavior.lastSequenceNumber(context) + 1: java.lang.Long)
                 Effect.persist(command.payload).thenRun(_ => command.replyTo ! Done)
               case Ping(replyTo) =>
                 replyTo ! Done
@@ -100,7 +100,7 @@ object DurableStateEndToEndSpec {
     override def process(session: R2dbcSession, envelope: DurableStateChange[String]): Future[Done] = {
       envelope match {
         case upd: UpdatedDurableState[String] =>
-          log.debug("{} Processed {} revision {}", projectionId.key, upd.value, upd.revision)
+          log.debug("{} Processed {} revision {}", projectionId.key, upd.value, upd.revision: java.lang.Long)
         case _ =>
       }
       processed :+= envelope

--- a/projection/src/test/scala/akka/projection/r2dbc/EventSourcedChaosSpec.scala
+++ b/projection/src/test/scala/akka/projection/r2dbc/EventSourcedChaosSpec.scala
@@ -76,7 +76,7 @@ object EventSourcedChaosSpec {
           projectionId.key,
           envelope.event,
           envelope.persistenceId,
-          envelope.sequenceNr)
+          envelope.sequenceNr: java.lang.Long)
         throw TestException(s"Fail event [${envelope.event}]")
       } else {
         log.debug(
@@ -84,7 +84,7 @@ object EventSourcedChaosSpec {
           projectionId.key,
           envelope.event,
           envelope.persistenceId,
-          envelope.sequenceNr)
+          envelope.sequenceNr: java.lang.Long)
         probe ! Processed(projectionId, envelope)
         Future.successful(Done)
       }
@@ -275,7 +275,7 @@ class EventSourcedChaosSpec
                 "Persisting events [{}], it will fail [{}] in projection [{}] times",
                 events.mkString(", "),
                 events(i),
-                failCount)
+                failCount: java.lang.Integer)
             } else {
               log.debug("Persisting events [{}]", events.mkString(", "))
             }

--- a/projection/src/test/scala/akka/projection/r2dbc/EventSourcedEndToEndSpec.scala
+++ b/projection/src/test/scala/akka/projection/r2dbc/EventSourcedEndToEndSpec.scala
@@ -71,16 +71,16 @@ object EventSourcedEndToEndSpec {
               case command: Persist =>
                 context.log.debug(
                   "Persist [{}], pid [{}], seqNr [{}]",
-                  command.payload,
+                  command.payload.toString,
                   pid.id,
-                  EventSourcedBehavior.lastSequenceNumber(context) + 1)
+                  EventSourcedBehavior.lastSequenceNumber(context) + 1: java.lang.Long)
                 Effect.persist(command.payload)
               case command: PersistWithAck =>
                 context.log.debug(
                   "Persist [{}], pid [{}], seqNr [{}]",
-                  command.payload,
+                  command.payload.toString,
                   pid.id,
-                  EventSourcedBehavior.lastSequenceNumber(context) + 1)
+                  EventSourcedBehavior.lastSequenceNumber(context) + 1: java.lang.Long)
                 Effect.persist(command.payload).thenRun(_ => command.replyTo ! Done)
               case command: PersistAll =>
                 if (context.log.isDebugEnabled)
@@ -88,7 +88,7 @@ object EventSourcedEndToEndSpec {
                     "PersistAll [{}], pid [{}], seqNr [{}]",
                     command.payloads.mkString(","),
                     pid.id,
-                    EventSourcedBehavior.lastSequenceNumber(context) + 1)
+                    EventSourcedBehavior.lastSequenceNumber(context) + 1: java.lang.Long)
                 Effect.persist(command.payloads)
               case Ping(replyTo) =>
                 replyTo ! Done
@@ -110,7 +110,7 @@ object EventSourcedEndToEndSpec {
     private val log = LoggerFactory.getLogger(getClass)
 
     override def process(session: R2dbcSession, envelope: EventEnvelope[String]): Future[Done] = {
-      log.debug("{} Processed {}", projectionId.key, envelope.event)
+      log.debug("{} Processed {}", projectionId.key: Any, envelope.event: Any)
       probe ! Processed(projectionId, envelope)
       Future.successful(Done)
     }
@@ -141,7 +141,7 @@ class EventSourcedEndToEndSpec
 
   // to be able to store events with specific timestamps
   private def writeEvent(persistenceId: String, seqNr: Long, timestamp: Instant, event: String): Unit = {
-    log.debug("Write test event [{}] [{}] [{}] at time [{}]", persistenceId, seqNr, event, timestamp)
+    log.debug("Write test event [{}] [{}] [{}] at time [{}]", persistenceId, seqNr: java.lang.Long, event, timestamp)
     val insertEventSql = sql"""
       INSERT INTO ${journalSettings.journalTableWithSchema}
       (slice, entity_type, persistence_id, seq_nr, db_timestamp, writer, adapter_manifest, event_ser_id, event_ser_manifest, event_payload)

--- a/projection/src/test/scala/akka/projection/r2dbc/EventSourcedPubSubSpec.scala
+++ b/projection/src/test/scala/akka/projection/r2dbc/EventSourcedPubSubSpec.scala
@@ -69,8 +69,8 @@ object EventSourcedPubSubSpec {
           projectionId.key,
           envelope.event,
           envelope.persistenceId,
-          envelope.sequenceNr,
-          directReplication)
+          envelope.sequenceNr: java.lang.Long,
+          directReplication: java.lang.Boolean)
         probe ! Processed(projectionId, envelope)
         Done
       }
@@ -191,13 +191,13 @@ class EventSourcedPubSubSpec
       }
 
       var processed = Vector.empty[Processed]
-      processed :++= expectProcessed(processedProbe, 1, 20)
+      processed ++= expectProcessed(processedProbe, 1, 20)
 
       (21 to 30).foreach { n =>
         val p = n % numberOfEntities
         entities(p) ! Persister.Persist(mkEvent(n))
       }
-      processed :++= expectProcessed(processedProbe, 21, 30)
+      processed ++= expectProcessed(processedProbe, 21, 30)
 
       // Processing of 31 is slow in the handler, see whenDone above.
       // This will overflow the buffer for the subscribers, simulating lost messages,
@@ -206,14 +206,14 @@ class EventSourcedPubSubSpec
         val p = n % numberOfEntities
         entities(p) ! Persister.Persist(mkEvent(n))
       }
-      processed :++= expectProcessed(processedProbe, 31, numberOfEvents - 10)
+      processed ++= expectProcessed(processedProbe, 31, numberOfEvents - 10)
 
       (numberOfEvents - 10 + 1 to numberOfEvents).foreach { n =>
         val p = n % numberOfEntities
         entities(p) ! Persister.Persist(mkEvent(n))
       }
 
-      processed :++= expectProcessed(processedProbe, numberOfEvents - 10 + 1, numberOfEvents)
+      processed ++= expectProcessed(processedProbe, numberOfEvents - 10 + 1, numberOfEvents)
 
       val byPid = processed.groupBy(_.envelope.persistenceId)
       byPid.foreach { case (pid, processedByPid) =>
@@ -227,7 +227,7 @@ class EventSourcedPubSubSpec
             p.envelope.offset.asInstanceOf[TimestampOffset].timestamp == p.envelope.offset
               .asInstanceOf[TimestampOffset]
               .readTimestamp)
-        log.info("via pub-sub {}: {}", pid, viaPubSub.map(_.envelope.sequenceNr).mkString(", "))
+        log.info("via pub-sub {}: {}", pid: Any, viaPubSub.map(_.envelope.sequenceNr).mkString(", "): Any)
       }
 
       val countViaPubSub = processed.count(p =>

--- a/projection/src/test/scala/akka/projection/r2dbc/R2dbcTimestampOffsetProjectionSpec.scala
+++ b/projection/src/test/scala/akka/projection/r2dbc/R2dbcTimestampOffsetProjectionSpec.scala
@@ -326,7 +326,7 @@ class R2dbcTimestampOffsetProjectionSpec
       createEnvelope(pid1, 6, startTime.plusMillis(9), s"e1-6"))
   }
 
-  def groupedHandler(probe: ActorRef[String]): R2dbcHandler[Seq[EventEnvelope[String]]] = {
+  def groupedHandler(probe: ActorRef[String]): R2dbcHandler[immutable.Seq[EventEnvelope[String]]] = {
     R2dbcHandler[immutable.Seq[EventEnvelope[String]]] { (session, envelopes) =>
       probe ! "called"
       if (envelopes.isEmpty)
@@ -771,8 +771,8 @@ class R2dbcTimestampOffsetProjectionSpec
       val result1 = new StringBuffer()
       val result2 = new StringBuffer()
 
-      def handler(): Handler[Seq[EventEnvelope[String]]] = new Handler[Seq[EventEnvelope[String]]] {
-        override def process(envelopes: Seq[EventEnvelope[String]]): Future[Done] = {
+      def handler(): Handler[immutable.Seq[EventEnvelope[String]]] = new Handler[immutable.Seq[EventEnvelope[String]]] {
+        override def process(envelopes: immutable.Seq[EventEnvelope[String]]): Future[Done] = {
           Future
             .successful {
               envelopes.foreach { envelope =>
@@ -811,8 +811,8 @@ class R2dbcTimestampOffsetProjectionSpec
       val result1 = new StringBuffer()
       val result2 = new StringBuffer()
 
-      def handler(): Handler[Seq[EventEnvelope[String]]] = new Handler[Seq[EventEnvelope[String]]] {
-        override def process(envelopes: Seq[EventEnvelope[String]]): Future[Done] = {
+      def handler(): Handler[immutable.Seq[EventEnvelope[String]]] = new Handler[immutable.Seq[EventEnvelope[String]]] {
+        override def process(envelopes: immutable.Seq[EventEnvelope[String]]): Future[Done] = {
           Future
             .successful {
               envelopes.foreach { envelope =>


### PR DESCRIPTION
This PR does the following

- Updates Scala 2.11 and 2.12 to the latest versions
- Replaces `setup-scala` with `setup-java`
  - As a result also needed to update how `.jvmopts-ci` is injected
- Adds support for Scala 2.11/2.12 to the CI by adding a matrix
- Updates to `ubuntu-latest` (the version of ubuntu in this project is so old that github no longer triggers the workflow runs)

Note that in this PR quite a few changes had to be done to get it to compile on Scala 2.12. Of note are the various type hinting (i.e. `: java.lang.Int` or `: Any` or `: Object`). This is all due to https://github.com/scala/bug/issues/12765. Also had to change from `scala.concurrent.ExecutionContext.parasitic` to `akka.dispatch.ExecutionContexts.parasitic` which is cross compiled for Scala 2.12/2.13.