### PR TITLE
Update sbt-apache-sonatype and handle rename

### DIFF
--- a/project/CommonSettings.scala
+++ b/project/CommonSettings.scala
@@ -8,7 +8,7 @@
  */
 
 import com.lightbend.paradox.projectinfo.ParadoxProjectInfoPlugin.autoImport.projectInfoVersion
-import org.mdedetrich.apache.sonatype.SonatypeApachePlugin
+import org.mdedetrich.apache.sonatype.ApacheSonatypePlugin
 import sbt.Keys._
 import sbt.{ AutoPlugin, Compile, CrossVersion, Global, Test, TestFrameworks, Tests }
 import sbt.plugins.JvmPlugin
@@ -18,7 +18,7 @@ import sbtdynver.DynVerPlugin.autoImport.dynverSonatypeSnapshots
 object CommonSettings extends AutoPlugin {
   override def trigger = allRequirements
 
-  override def requires = JvmPlugin && SonatypeApachePlugin && DynVerPlugin
+  override def requires = JvmPlugin && ApacheSonatypePlugin && DynVerPlugin
 
   override lazy val projectSettings = Seq(
     crossScalaVersions := Seq(Dependencies.Scala212, Dependencies.Scala213),

--- a/project/MetaInfLicenseNoticeCopy.scala
+++ b/project/MetaInfLicenseNoticeCopy.scala
@@ -9,8 +9,8 @@
 
 import sbt.Keys._
 import sbt._
-import org.mdedetrich.apache.sonatype.SonatypeApachePlugin
-import org.mdedetrich.apache.sonatype.SonatypeApachePlugin.autoImport._
+import org.mdedetrich.apache.sonatype.ApacheSonatypePlugin
+import org.mdedetrich.apache.sonatype.ApacheSonatypePlugin.autoImport._
 
 /**
  * Copies LICENSE and NOTICE files into jar META-INF dir
@@ -24,5 +24,5 @@ object MetaInfLicenseNoticeCopy extends AutoPlugin {
 
   override def trigger = allRequirements
 
-  override def requires = SonatypeApachePlugin
+  override def requires = ApacheSonatypePlugin
 }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -3,7 +3,7 @@ addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.5.0")
 addSbtPlugin("com.lightbend.sbt" % "sbt-java-formatter" % "0.7.0")
 
 // for releasing
-addSbtPlugin("org.mdedetrich" % "sbt-apache-sonatype" % "0.1.6")
+addSbtPlugin("org.mdedetrich" % "sbt-apache-sonatype" % "0.1.7")
 addSbtPlugin("com.dwijnand" % "sbt-dynver" % "4.1.1")
 addSbtPlugin("com.github.pjfanning" % "sbt-source-dist" % "0.1.5")
 


### PR DESCRIPTION
Updates sbt-apache-sonatype. Note that this new version renames `SonatypeApachePlugin` to `ApacheSonatypePlugin` to be consistent with the project name.