### PR TITLE
Add .git-blame-ignore-revs

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,5 @@
+# scalafmt
+97a7214a3ec0aa1a2ee6debcd0fce9ab6aa67492
+
+# manual
+0dd31ce2c4f9673bd1a8c4b9ef4233559a188af4

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -122,6 +122,16 @@ Which licenses are compatible with Apache 2 are defined in [this doc](http://www
 
 > Each license in this category requires some degree of [reciprocity](http://www.apache.org/legal/3party.html#define-reciprocal); therefore, additional action must be taken in order to minimize the chance that a user of an Apache product will create a derivative work of a reciprocally-licensed portion of an Apache product without being aware of the applicable requirements.
 
+### Ignoring formatting commits in git blame
+
+Throughout the history of the codebase various formatting commits have been applied as the scalafmt style has evolved over time, if desired
+one can setup git blame to ignore these commits. The hashes for these specific are stored in [this file](.git-blame-ignore-revs) so to configure
+git blame to ignore these commits you can execute the following.
+
+```shell
+git config blame.ignoreRevsFile .git-blame-ignore-revs
+```
+
 ## Creating Commits And Writing Commit Messages
 
 Follow these guidelines when creating public commits and writing commit messages.


### PR DESCRIPTION
The project didn't have it in the first place. Added https://github.com/apache/incubator-pekko-persistence-r2dbc/pull/27 and https://github.com/apache/incubator-pekko-persistence-r2dbc/pull/3 to `.git-blame-ignore-revs` and also documented `CONTRIBUTING.md`.