### PR TITLE
Use proper type for SemVerSpec

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 ThisBuild / resolvers += Resolver.ApacheMavenSnapshotsRepo
 ThisBuild / apacheSonatypeProjectProfile := "pekko"
-ThisBuild / versionScheme := Some("semver-spec")
+ThisBuild / versionScheme := Some(VersionScheme.SemVerSpec)
 sourceDistName := "incubating-pekko-persistence-r2dbc"
 
 import sbt.Keys.parallelExecution


### PR DESCRIPTION
There is an actual proper type for `SemVerSpec` which is better than using a `String`.