### PR TITLE
Use fetch tags from latest checkout action

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -17,9 +17,10 @@ jobs:
         JAVA_VERSION: [ 8, 11, 17 ]
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          fetch-tags: true
 
       - name: Setup Java ${{ matrix.JAVA_VERSION }}
         uses: actions/setup-java@v3
@@ -41,9 +42,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          fetch-tags: true
 
       - name: Setup Java 8
         uses: actions/setup-java@v3
@@ -70,9 +72,10 @@ jobs:
     if: github.repository == 'apache/incubator-pekko-persistence-r2dbc'
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          fetch-tags: true
 
       - name: Checkout GitHub merge
         if: github.event.pull_request
@@ -108,9 +111,10 @@ jobs:
     if: github.repository == 'apache/incubator-pekko-persistence-r2dbc'
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          fetch-tags: true
 
       - name: Checkout GitHub merge
         if: github.event.pull_request
@@ -150,9 +154,10 @@ jobs:
     if: github.repository == 'apache/incubator-pekko-persistence-r2dbc'
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          fetch-tags: true
 
       - name: Checkout GitHub merge
         if: github.event.pull_request
@@ -188,9 +193,10 @@ jobs:
     if: github.repository == 'apache/incubator-pekko-persistence-r2dbc'
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          fetch-tags: true
 
       - name: Checkout GitHub merge
         if: github.event.pull_request

--- a/.github/workflows/dependency-graph.yml
+++ b/.github/workflows/dependency-graph.yml
@@ -9,5 +9,5 @@ jobs:
     runs-on: ubuntu-latest
     if: github.repository == 'apache/incubator-pekko-persistence-r2dbc'
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: scalacenter/sbt-dependency-submission@v2

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout current branch (full)
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
           persist-credentials: false

--- a/.github/workflows/headers.yml
+++ b/.github/workflows/headers.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Java 11
         uses: actions/setup-java@v3

--- a/.github/workflows/publish-nightly.yml
+++ b/.github/workflows/publish-nightly.yml
@@ -15,10 +15,11 @@ jobs:
       JAVA_OPTS: -Xms2G -Xmx2G -Xss2M -XX:ReservedCodeCacheSize=256M -Dfile.encoding=UTF-8
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           # we don't know what commit the last tag was it's safer to get entire repo so previousStableVersion resolves
           fetch-depth: 0
+          fetch-tags: true
 
       - name: Setup Java 8
         uses: actions/setup-java@v3


### PR DESCRIPTION
The latest version of the checkout github actions now supports a `fetch-tags` flag which does as described, i.e. it will fetch all of our tags which removes the various workarounds that was used before (i.e. manually running `git fetch` command) etc etc, see https://github.com/actions/checkout/pull/579

This will also help in the erroneous errors that we get in CI, i.e. 

```
[error] Failed to derive version from git tags. Maybe run `git fetch --unshallow` or `git fetch upstream` on a fresh git clone from a fork? Derived version: 0.0.0+1-337943bd-SNAPSHOT`
```