### PR TITLE
Update r2dbc dependencies

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -32,8 +32,8 @@ object Dependencies {
     val pekkoProjectionCore = "org.apache.pekko" %% "pekko-projection-core" % PekkoProjectionVersion
 
     val r2dbcSpi = "io.r2dbc" % "r2dbc-spi" % "0.9.1.RELEASE"
-    val r2dbcPool = "io.r2dbc" % "r2dbc-pool" % "0.9.1.RELEASE"
-    val r2dbcPostgres = "org.postgresql" % "r2dbc-postgresql" % "0.9.1.RELEASE"
+    val r2dbcPool = "io.r2dbc" % "r2dbc-pool" % "0.9.2.RELEASE"
+    val r2dbcPostgres = "org.postgresql" % "r2dbc-postgresql" % "0.9.3.RELEASE"
   }
 
   object TestDeps {


### PR DESCRIPTION
The context for this is an upcoming PR to add license-report and updating these dependencies will make things slightly easier in the long run.

The dependencies being updated are bincompat so there shouldn't be any issues