### PR TITLE
Add sbt-license-report

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -110,4 +110,11 @@ lazy val docs = project
       "scaladoc.scala.base_url" -> s"https://www.scala-lang.org/api/current/",
       "scaladoc.org.apache.pekko.base_url" -> s"https://pekko.apache.org/api/pekko/${Dependencies.PekkoVersion}",
       "scaladoc.com.typesafe.config.base_url" -> s"https://lightbend.github.io/config/latest/api/"),
-    apidocRootPackage := "org.apache.pekko")
+    apidocRootPackage := "org.apache.pekko",
+    Compile / paradoxMarkdownToHtml / sourceGenerators += Def.taskDyn {
+      val targetFile = (Compile / paradox / sourceManaged).value / "license-report.md"
+
+      (LocalRootProject / dumpLicenseReportAggregate).map { dir =>
+        IO.copy(List(dir / "pekko-persistence-r2dbc-root-licenses.md" -> targetFile)).toList
+      }
+    }.taskValue)

--- a/docs/src/main/paradox/index.md
+++ b/docs/src/main/paradox/index.md
@@ -9,6 +9,7 @@ The Pekko Persistence R2DBC plugin allows for using SQL database with R2DBC as a
 * [overview](overview.md)
 * [Getting Started](getting-started.md)
 * [Getting Started](connection-config.md)
+* [License Report](license-report.md)
 * [Journal Plugin](journal.md)
 * [Snapshot Plugin](snapshots.md)
 * [Durable State Plugin](durable-state-store.md)

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -33,7 +33,15 @@ object Dependencies {
 
     val r2dbcSpi = "io.r2dbc" % "r2dbc-spi" % "0.9.1.RELEASE"
     val r2dbcPool = "io.r2dbc" % "r2dbc-pool" % "0.9.2.RELEASE"
-    val r2dbcPostgres = "org.postgresql" % "r2dbc-postgresql" % "0.9.3.RELEASE"
+
+    // This is here because sbt's ivy resolver doesn't properly support packaging.type when
+    // resolving via sbt-license-report, see https://github.com/sbt/sbt-license-report/issues/87
+    val r2dbcPostgres = Seq(
+      ("org.postgresql" % "r2dbc-postgresql" % "0.9.3.RELEASE").excludeAll(
+        "io.netty.incubator", "netty-incubator-codec-native-quic"),
+      ("io.netty.incubator" % "netty-incubator-codec-native-quic" % "0.0.33.Final")
+        .artifacts(Artifact("netty-incubator-codec-native-quic",
+          url("https://repo1.maven.org/maven2/io/netty/incubator/netty-incubator-codec-native-quic/0.0.33.Final/netty-incubator-codec-native-quic-0.0.33.Final.jar"))))
   }
 
   object TestDeps {
@@ -52,10 +60,10 @@ object Dependencies {
 
     val postgresql = "org.postgresql" % "postgresql" % "42.3.8" % Test
 
-    val logback = "ch.qos.logback" % "logback-classic" % "1.2.11" % Test // EPL 1.0 / LGPL 2.1
-    val scalaTest = "org.scalatest" %% "scalatest" % "3.2.14" % Test // ApacheV2
-    val junit = "junit" % "junit" % "4.12" % Test // Eclipse Public License 1.0
-    val junitInterface = "com.novocode" % "junit-interface" % "0.11" % Test // "BSD 2-Clause"
+    val logback = "ch.qos.logback" % "logback-classic" % "1.2.11" % Test
+    val scalaTest = "org.scalatest" %% "scalatest" % "3.2.14" % Test
+    val junit = "junit" % "junit" % "4.12" % Test
+    val junitInterface = "com.novocode" % "junit-interface" % "0.11" % Test
   }
 
   import Compile._
@@ -65,19 +73,17 @@ object Dependencies {
     pekkoPersistenceQuery,
     r2dbcSpi,
     r2dbcPool,
-    r2dbcPostgres,
     TestDeps.pekkoPersistenceTck,
     TestDeps.pekkoStreamTestkit,
     TestDeps.pekkoTestkit,
     TestDeps.pekkoJackson,
     TestDeps.logback,
-    TestDeps.scalaTest)
+    TestDeps.scalaTest) ++ r2dbcPostgres
 
   val projection = Seq(
     pekkoPersistenceQuery,
     r2dbcSpi,
     r2dbcPool,
-    r2dbcPostgres,
     pekkoProjectionCore,
     TestDeps.pekkoProjectionEventSourced,
     TestDeps.pekkoProjectionDurableState,
@@ -86,7 +92,7 @@ object Dependencies {
     TestDeps.pekkoProjectionTestKit,
     TestDeps.pekkoJackson,
     TestDeps.logback,
-    TestDeps.scalaTest)
+    TestDeps.scalaTest) ++ r2dbcPostgres
 
   val migration =
     Seq(

--- a/project/LicenseReport.scala
+++ b/project/LicenseReport.scala
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import sbt._
+import sbtlicensereport.SbtLicenseReport
+import sbtlicensereport.SbtLicenseReport.autoImportImpl._
+import sbtlicensereport.license.{ DepModuleInfo, LicenseInfo, MarkDown }
+
+object LicenseReport extends AutoPlugin {
+
+  override lazy val projectSettings = Seq(
+    licenseReportTypes := Seq(MarkDown),
+    licenseReportMakeHeader := (language => language.header1("License Report")),
+    licenseConfigurations := {
+      Set("compile", "test", "provided")
+    },
+    licenseDepExclusions := {
+      case DepModuleInfo("org.apache.pekko", _, _) => true // Inter pekko project dependencies are pointless
+      case DepModuleInfo(_, "scala-library", _)    => true // Scala library is part of Scala language
+    },
+    licenseOverrides := {
+      // This is here because of the workaround in project/plugins.sbt, i.e.
+      // https://github.com/sbt/sbt-license-report/issues/87
+      case DepModuleInfo("io.netty.incubator", "netty-incubator-codec-native-quic", _) => LicenseInfo.APACHE2
+    },
+    licenseReportColumns := Seq(
+      Column.Category,
+      Column.License,
+      Column.Dependency,
+      Column.OriginatingArtifactName,
+      Column.Configuration))
+
+  override def requires = plugins.JvmPlugin && SbtLicenseReport
+
+  override def trigger = allRequirements
+
+}

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -17,6 +17,7 @@ addSbtPlugin("org.mdedetrich" % "sbt-apache-sonatype" % "0.1.10")
 addSbtPlugin("com.dwijnand" % "sbt-dynver" % "4.1.1")
 addSbtPlugin("net.bzzt" % "sbt-reproducible-builds" % "0.31")
 addSbtPlugin("com.github.pjfanning" % "sbt-source-dist" % "0.1.10")
+addSbtPlugin("com.github.sbt" % "sbt-license-report" % "1.6.1")
 
 //// docs
 


### PR DESCRIPTION
Adds sbt-license-report. Unfortunately one of our dependencies is using `packaging.type` which sbt-license-report cannot currently handle (see https://github.com/sbt/sbt-license-report/issues/87) so a workaround for the `io.netty.incubator:netty-incubator-codec-native-quic` was needed (also see https://github.com/apache/incubator-pekko-persistence-r2dbc/pull/60#issuecomment-1717880994 for context).